### PR TITLE
feat: process networking now uses a single protocol config

### DIFF
--- a/pkg/krt/krt.go
+++ b/pkg/krt/krt.go
@@ -94,10 +94,9 @@ func (s ObjectStoreScope) IsValid() bool {
 }
 
 type ProcessNetworking struct {
-	TargetPort          int                `yaml:"targetPort" default:"9000" `
-	TargetProtocol      NetworkingProtocol `yaml:"targetProtocol" default:"TCP" `
-	DestinationPort     int                `yaml:"destinationPort" default:"9000" `
-	DestinationProtocol NetworkingProtocol `yaml:"destinationProtocol" default:"TCP" `
+	TargetPort      int                `yaml:"targetPort" default:"9000" `
+	DestinationPort int                `yaml:"destinationPort" default:"9000" `
+	Protocol        NetworkingProtocol `yaml:"protocol" default:"TCP" `
 }
 
 type NetworkingProtocol string

--- a/pkg/krt/validations_process.go
+++ b/pkg/krt/validations_process.go
@@ -127,14 +127,6 @@ func (process *Process) validateNetworking(workflowIdx, processIdx int) error {
 		)
 	}
 
-	if !process.Networking.TargetProtocol.IsValid() {
-		totalError = errors.Join(
-			totalError, errors.InvalidNetworkingProtocolError(
-				fmt.Sprintf("krt.workflows[%d].processes[%d].networking.targetProtocol", workflowIdx, processIdx),
-			),
-		)
-	}
-
 	if process.Networking.DestinationPort == 0 {
 		totalError = errors.Join(
 			totalError,
@@ -144,11 +136,10 @@ func (process *Process) validateNetworking(workflowIdx, processIdx int) error {
 		)
 	}
 
-	if !process.Networking.DestinationProtocol.IsValid() {
+	if !process.Networking.Protocol.IsValid() {
 		totalError = errors.Join(
-			totalError,
-			errors.InvalidNetworkingProtocolError(
-				fmt.Sprintf("krt.workflows[%d].processes[%d].networking.destinationProtocol", workflowIdx, processIdx),
+			totalError, errors.InvalidNetworkingProtocolError(
+				fmt.Sprintf("krt.workflows[%d].processes[%d].networking.protocol", workflowIdx, processIdx),
 			),
 		)
 	}

--- a/pkg/krt/validations_test.go
+++ b/pkg/krt/validations_test.go
@@ -112,9 +112,8 @@ func TestKrtValidator(t *testing.T) {
 			name: "fails if krt hasn't required networking target port if declared",
 			krtYaml: NewKrtBuilder().WithProcessNetworking(
 				&krt.ProcessNetworking{
-					TargetProtocol:      "UDP",
-					DestinationPort:     9000,
-					DestinationProtocol: "UDP",
+					DestinationPort: 9000,
+					Protocol:        "UDP",
 				},
 				0,
 			).Build(),
@@ -126,9 +125,8 @@ func TestKrtValidator(t *testing.T) {
 			name: "fails if krt hasn't required networking destination port if declared",
 			krtYaml: NewKrtBuilder().WithProcessNetworking(
 				&krt.ProcessNetworking{
-					TargetPort:          9000,
-					TargetProtocol:      "UDP",
-					DestinationProtocol: "UDP",
+					TargetPort: 9000,
+					Protocol:   "UDP",
 				},
 				0,
 			).Build(),
@@ -274,34 +272,18 @@ func TestKrtValidator(t *testing.T) {
 			errorString: errors.InvalidProcessObjectStoreScopeError("krt.workflows[0].processes[0].objectStore.scope").Error(),
 		},
 		{
-			name: "fails if krt hasn't a valid process networking target protocol",
+			name: "fails if krt hasn't a valid process networking protocol",
 			krtYaml: NewKrtBuilder().WithProcessNetworking(
 				&krt.ProcessNetworking{
-					TargetPort:          9000,
-					TargetProtocol:      invalidName,
-					DestinationPort:     9000,
-					DestinationProtocol: "UDP",
+					TargetPort:      9000,
+					DestinationPort: 9000,
+					Protocol:        invalidName,
 				},
 				0,
 			).Build(),
 			wantError:   true,
 			errorType:   errors.ErrInvalidNetworkingProtocol,
-			errorString: errors.InvalidNetworkingProtocolError("krt.workflows[0].processes[0].networking.targetProtocol").Error(),
-		},
-		{
-			name: "fails if krt hasn't a valid process networking destination protocol",
-			krtYaml: NewKrtBuilder().WithProcessNetworking(
-				&krt.ProcessNetworking{
-					TargetPort:          9000,
-					TargetProtocol:      "UDP",
-					DestinationPort:     9000,
-					DestinationProtocol: invalidName,
-				},
-				0,
-			).Build(),
-			wantError:   true,
-			errorType:   errors.ErrInvalidNetworkingProtocol,
-			errorString: errors.InvalidNetworkingProtocolError("krt.workflows[0].processes[0].networking.destinationProtocol").Error(),
+			errorString: errors.InvalidNetworkingProtocolError("krt.workflows[0].processes[0].networking.protocol").Error(),
 		},
 	}
 

--- a/pkg/parse/parse_test.go
+++ b/pkg/parse/parse_test.go
@@ -47,8 +47,8 @@ func TestCorrectKrtFileSettingDefaults(t *testing.T) {
 			if idxWorkflow == 0 && idxProcess == 0 {
 				assert.True(t, *process.GPU)
 				assert.Equal(t, 2, *process.Replicas)
-				assert.Equal(t, krt.NetworkingProtocolUDP, process.Networking.DestinationProtocol)
-				assert.Equal(t, krt.NetworkingProtocolUDP, process.Networking.TargetProtocol)
+				assert.Equal(t, 9000, process.Networking.DestinationPort)
+				assert.Equal(t, krt.NetworkingProtocolTCP, process.Networking.Protocol)
 			} else if idxWorkflow == 0 && idxProcess == 1 {
 				assert.Nil(t, process.Networking)
 			} else {
@@ -57,9 +57,8 @@ func TestCorrectKrtFileSettingDefaults(t *testing.T) {
 				assert.GreaterOrEqual(t, *process.Replicas, 1)
 				if process.Networking != nil {
 					assert.NotEmpty(t, process.Networking.TargetPort)
-					assert.NotEmpty(t, process.Networking.TargetProtocol)
 					assert.NotEmpty(t, process.Networking.DestinationPort)
-					assert.NotEmpty(t, process.Networking.DestinationProtocol)
+					assert.NotEmpty(t, process.Networking.Protocol)
 				}
 			}
 		}

--- a/pkg/parse/test_files/correct_krt.yaml
+++ b/pkg/parse/test_files/correct_krt.yaml
@@ -19,9 +19,8 @@ workflows:
           - 'exitpoint'
         networking:
           targetPort: 9000
-          targetProtocol: TCP
           destinationPort: 9000
-          destinationProtocol: TCP
+          protocol: TCP
 
       - name: etl
         type: task
@@ -82,9 +81,8 @@ workflows:
           - 'exitpoint'
         networking:
           targetPort: 9000
-          targetProtocol: TCP
           destinationPort: 9000
-          destinationProtocol: TCP
+          protocol: TCP
 
       - name: etl
         type: task

--- a/pkg/parse/test_files/missing_defaults_krt.yaml
+++ b/pkg/parse/test_files/missing_defaults_krt.yaml
@@ -20,8 +20,7 @@ workflows:
         subscriptions:
           - 'exitpoint'
         networking:
-          targetProtocol: 'UDP'
-          destinationProtocol: 'UDP'
+          targetPort: 8000
 
       - name: etl
         type: task

--- a/pkg/parse/test_files/not_valid_types_krt.yaml
+++ b/pkg/parse/test_files/not_valid_types_krt.yaml
@@ -14,9 +14,8 @@ workflows:
           - 'exitpoint'
         networking:
           targetPort: 9000
-          targetProtocol: invalid
           destinationPort: 9000
-          destinationProtocol: invalid
+          protocol: invalid
 
       - name: exitpoint
         type: invalid


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Deprecate DestinationProtocol and TargetProtocol in favor of a single "Protocol" variable. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Kubernetes does only need 1 protocol config that applies to both ends.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have created tests for my code changes, and the tests are passing.
- [X] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
