### PR TITLE
feat(krt): triggers dont require subscriptions

### DIFF
--- a/pkg/krt/validations_process.go
+++ b/pkg/krt/validations_process.go
@@ -119,7 +119,7 @@ func (process *Process) ValidateSubscriptions(workflowIdx, processIdx int) error
 }
 
 // validateSubscritpionRelationships checks if subscriptions for all processes are valid
-// inisde a workflow context.
+// inside a workflow context.
 //
 // All requirements for subscritpions to be valid can be found in the readme.
 func validateSubscritpionRelationships(processes []Process, workflowIdx int) error {

--- a/pkg/krt/validations_process.go
+++ b/pkg/krt/validations_process.go
@@ -102,7 +102,11 @@ func (process *Process) ValidateSecrets(workflowIdx, processIdx int) error {
 }
 
 func (process *Process) ValidateSubscriptions(workflowIdx, processIdx int) error {
-	if process.Subscriptions == nil {
+	if process.Type == ProcessTypeTrigger {
+		return nil
+	}
+
+	if process.Subscriptions == nil || len(process.Subscriptions) == 0 {
 		return errors.MissingRequiredFieldError(
 			fmt.Sprintf("krt.workflows[%d].processes[%d].subscriptions",
 				workflowIdx,
@@ -114,9 +118,11 @@ func (process *Process) ValidateSubscriptions(workflowIdx, processIdx int) error
 	return nil
 }
 
-// validateSubscritpions checks if subscriptions for all process are valid.
+// validateSubscritpionRelationships checks if subscriptions for all processes are valid
+// inisde a workflow context.
+//
 // All requirements for subscritpions to be valid can be found in the readme.
-func validateSubscritpions(processes []Process, workflowIdx int) error {
+func validateSubscritpionRelationships(processes []Process, workflowIdx int) error {
 	var totalError error
 
 	processTypesByNames, err := countProcessesSubscriptions(processes, workflowIdx)

--- a/pkg/krt/validations_test.go
+++ b/pkg/krt/validations_test.go
@@ -97,10 +97,15 @@ func TestKrtValidator(t *testing.T) {
 		},
 		{
 			name:        "fails if krt hasn't required process subscriptions",
-			krtYaml:     NewKrtBuilder().WithProcessSubscriptions(nil, 0).Build(),
+			krtYaml:     NewKrtBuilder().WithProcessSubscriptions(nil, 1).Build(),
 			wantError:   true,
 			errorType:   errors.ErrMissingRequiredField,
-			errorString: errors.MissingRequiredFieldError("krt.workflows[0].processes[0].subscriptions").Error(),
+			errorString: errors.MissingRequiredFieldError("krt.workflows[0].processes[1].subscriptions").Error(),
+		},
+		{
+			name:      "does not fail if krt hasn't required process subscriptions for a trigger",
+			krtYaml:   NewKrtBuilder().WithProcessSubscriptions(nil, 0).Build(),
+			wantError: false,
 		},
 		{
 			name: "fails if krt hasn't required networking target port if declared",

--- a/pkg/krt/validations_workflow.go
+++ b/pkg/krt/validations_workflow.go
@@ -44,7 +44,7 @@ func (workflow *Workflow) ValidateProcesses(workflowIdx int) error {
 			totalError = errors.Join(totalError, process.Validate(workflowIdx, idx))
 		}
 
-		totalError = errors.Join(totalError, validateSubscritpions(workflow.Processes, workflowIdx))
+		totalError = errors.Join(totalError, validateSubscritpionRelationships(workflow.Processes, workflowIdx))
 	}
 
 	return totalError


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Check for subscriptions no longer applies to trigger processes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trigger processes don't need to declare any subscriptions as they can be webhooks for example.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have created tests for my code changes, and the tests are passing.
- [ ] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
